### PR TITLE
COR-1073 Add support for writing counters and gauges as single multi-field line in InfluxMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterPartition.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterPartition.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.influx;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.util.AbstractPartition;
+
+import java.util.List;
+
+/**
+ * {@link AbstractPartition} for Influx {@link Meter}.
+ *
+ * @author Mariusz Sondecki
+ */
+class InfluxMeterPartition<T> extends AbstractPartition<T> {
+
+    InfluxMeterPartition(List<T> list, int partitionSize) {
+        super(list, partitionSize);
+    }
+
+    static <T> List<List<T>> partition(List<T> list, int partitionSize) {
+        return new InfluxMeterPartition<>(list, partitionSize);
+    }
+
+}

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -16,21 +16,28 @@
 package io.micrometer.influx;
 
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
-import io.micrometer.core.instrument.util.*;
+import io.micrometer.core.instrument.util.DoubleFormat;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
+import io.micrometer.core.instrument.util.StringUtils;
+import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.net.MalformedURLException;
 import java.net.URLEncoder;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.joining;
 
 /**
@@ -38,18 +45,20 @@ import static java.util.stream.Collectors.joining;
  *
  * @author Jon Schneider
  * @author Johnny Lim
+ * @author Mariusz Sondecki
  */
 public class InfluxMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("influx-metrics-publisher");
     private final InfluxConfig config;
     private final HttpSender httpClient;
     private final Logger logger = LoggerFactory.getLogger(InfluxMeterRegistry.class);
+    private final Set<String> prefixes;
     private boolean databaseExists = false;
 
     @SuppressWarnings("deprecation")
     public InfluxMeterRegistry(InfluxConfig config, Clock clock) {
         this(config, clock, DEFAULT_THREAD_FACTORY,
-                new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()));
+                new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()), emptySet());
     }
 
     /**
@@ -60,14 +69,15 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
      */
     @Deprecated
     public InfluxMeterRegistry(InfluxConfig config, Clock clock, ThreadFactory threadFactory) {
-        this(config, clock, threadFactory, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()));
+        this(config, clock, threadFactory, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()), emptySet());
     }
 
-    private InfluxMeterRegistry(InfluxConfig config, Clock clock, ThreadFactory threadFactory, HttpSender httpClient) {
+    private InfluxMeterRegistry(InfluxConfig config, Clock clock, ThreadFactory threadFactory, HttpSender httpClient, Set<String> prefixes) {
         super(config, clock);
         config().namingConvention(new InfluxNamingConvention());
         this.config = config;
         this.httpClient = httpClient;
+        this.prefixes = prefixes;
         start(threadFactory);
     }
 
@@ -117,34 +127,103 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                 influxEndpoint += "&rp=" + config.retentionPolicy();
             }
 
-            for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
-                httpClient.post(influxEndpoint)
-                        .withBasicAuthentication(config.userName(), config.password())
-                        .withPlainText(batch.stream()
-                                .flatMap(m -> m.match(
-                                        gauge -> writeGauge(gauge.getId(), gauge.value()),
-                                        counter -> writeCounter(counter.getId(), counter.count()),
-                                        this::writeTimer,
-                                        this::writeSummary,
-                                        this::writeLongTaskTimer,
-                                        gauge -> writeGauge(gauge.getId(), gauge.value(getBaseTimeUnit())),
-                                        counter -> writeCounter(counter.getId(), counter.count()),
-                                        this::writeFunctionTimer,
-                                        this::writeMeter))
-                                .collect(joining("\n")))
-                        .compressWhen(config::compressed)
-                        .send()
-                        .onSuccess(response -> {
-                            logger.debug("successfully sent {} metrics to InfluxDB.", batch.size());
-                            databaseExists = true;
-                        })
-                        .onError(response -> logger.error("failed to send metrics to influx: {}", response.body()));
+            if (prefixes == null || prefixes.isEmpty()) {
+                logger.info("prefixes are empty");
+                publishMetrics(influxEndpoint, getMeters());
+            } else {
+                splitAndPublishMetrics(influxEndpoint);
             }
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Malformed InfluxDB publishing endpoint, see '" + config.prefix() + ".uri'", e);
         } catch (Throwable e) {
             logger.error("failed to send metrics to influx", e);
         }
+    }
+
+    private void splitAndPublishMetrics(String influxEndpoint) throws Throwable {
+        final Map<MeterKey, List<Meter>> matchedMetersMap = new HashMap<>();
+        final List<Meter> unmatchedMeters = new ArrayList<>();
+
+        for (Meter meter : getMeters()) {
+            final MeterKey key = createKeyIfMatched(meter);
+            if (key != null) {
+                matchedMetersMap.computeIfAbsent(key, k -> new ArrayList<>()).add(meter);
+            } else {
+                unmatchedMeters.add(meter);
+            }
+        }
+
+        publishMetrics(influxEndpoint, unmatchedMeters);
+        publishMetrics(influxEndpoint, matchedMetersMap);
+    }
+
+    // VisibleForTesting
+    MeterKey createKeyIfMatched(Meter meter) {
+        if (meter instanceof Gauge || meter instanceof Counter || meter instanceof FunctionCounter) {
+            final Meter.Id meterId = meter.getId();
+            final String meterName = meterId.getName();
+            final String baseUnit = meterId.getBaseUnit();
+            final Predicate<String> matchedPredicate = prefix -> meterName.length() > prefix.concat(".").length() && meterName.startsWith(prefix + ".");
+
+            return prefixes.stream()
+                    .filter(matchedPredicate)
+                    .findFirst()
+                    .map(matchedPrefix -> new MeterKey(meterId.getType(), matchedPrefix, meterId.getTags(), baseUnit))
+                    .orElse(null);
+        }
+        return null;
+    }
+
+    private void publishMetrics(String influxEndpoint, List<Meter> meters) throws Throwable {
+        logger.debug("publish meters without prefixes");
+        for (List<Meter> batch : InfluxMeterPartition.partition(meters, config.batchSize())) {
+            publishMetrics(influxEndpoint, batch.size(), batch.stream()
+                    .flatMap(m -> m.match(
+                            gauge -> writeGauge(gauge.getId(), gauge.value()),
+                            counter -> writeCounter(counter.getId(), counter.count()),
+                            this::writeTimer,
+                            this::writeSummary,
+                            this::writeLongTaskTimer,
+                            gauge -> writeGauge(gauge.getId(), gauge.value(getBaseTimeUnit())),
+                            counter -> writeCounter(counter.getId(), counter.count()),
+                            this::writeFunctionTimer,
+                            this::writeMeter))
+                    .collect(joining("\n")));
+        }
+    }
+
+    private void publishMetrics(String influxEndpoint, Map<MeterKey, List<Meter>> metersMap) throws Throwable {
+        logger.debug("publish meters with prefixes");
+        for (List<MeterKey> batch : InfluxMeterPartition.partition(metersMap.keySet().stream().collect(Collectors.toList()), config.batchSize())) {
+            publishMetrics(influxEndpoint, batch.size(), batch.stream()
+                    .flatMap(k -> writeMetersAsSingleMultiFieldLine(metersMap.get(k),
+                            meter -> match(meter,
+                                    Gauge::value,
+                                    Counter::count,
+                                    timeGauge -> timeGauge.value(getBaseTimeUnit()),
+                                    FunctionCounter::count),
+                            getConventionName(k)))
+                    .collect(joining("\n")));
+        }
+    }
+
+    private void publishMetrics(String influxEndpoint, int metersCount, String content) throws Throwable {
+        logger.debug("send to InfluxDB metrics: {}", content);
+        httpClient.post(influxEndpoint)
+                .withBasicAuthentication(config.userName(), config.password())
+                .withPlainText(content)
+                .compressWhen(config::compressed)
+                .send()
+                .onSuccess(response -> {
+                    logger.debug("successfully sent {} metrics to InfluxDB.", metersCount);
+                    databaseExists = true;
+                })
+                .onError(response -> logger.error("failed to send metrics to influx: {}", response.body()));
+    }
+
+    // VisibleForTesting
+    String getConventionName(MeterKey k) {
+        return config().namingConvention().name(k.getPrefix(), k.getMeterType(), k.getBaseUnit());
     }
 
     // VisibleForTesting
@@ -174,6 +253,22 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         return Stream.of(influxLineProtocol(timer.getId(), "long_task_timer", fields));
     }
 
+    private <T> T match(Meter meter,
+                        Function<Gauge, T> visitGauge,
+                        Function<Counter, T> visitCounter,
+                        Function<TimeGauge, T> visitTimeGauge,
+                        Function<FunctionCounter, T> visitFunctionCounter) {
+        if (meter instanceof TimeGauge) {
+            return visitTimeGauge.apply((TimeGauge) meter);
+        } else if (meter instanceof Gauge) {
+            return visitGauge.apply((Gauge) meter);
+        } else if (meter instanceof FunctionCounter) {
+            return visitFunctionCounter.apply((FunctionCounter) meter);
+        }  else {
+            return visitCounter.apply((Counter) meter);
+        }
+    }
+
     // VisibleForTesting
     Stream<String> writeCounter(Meter.Id id, double count) {
         if (Double.isFinite(count)) {
@@ -188,6 +283,34 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
             return Stream.of(influxLineProtocol(id, "gauge", Stream.of(new Field("value", value))));
         }
         return Stream.empty();
+    }
+
+    // VisibleForTesting
+    Stream<String> writeMetersAsSingleMultiFieldLine(List<Meter> meters, Function<Meter, Double> meterMeasurement, String meterName) {
+        final List<Field> fields = new ArrayList<>();
+        for (Meter meter : meters) {
+            final Field field = createFieldForMeter(meterMeasurement, meterName, meter);
+            if (field != null) {
+                fields.add(field);
+            }
+        }
+        if (fields.isEmpty()) {
+            return Stream.empty();
+        }
+        final Meter.Id id = meters.get(0).getId();//get first from list, because all have the same tags
+        return Stream.of(influxLineProtocol(id, id.getType().name().toLowerCase(), fields.stream(), meterName));
+    }
+
+    private Field createFieldForMeter(Function<Meter, Double> meterMeasurement, String meterName, Meter meter) {
+        final Double value = meterMeasurement.apply(meter);
+        if (!Double.isFinite(value)) {
+            return null;
+        }
+        final Meter.Id id = meter.getId();
+        final String fullConventionName = getConventionName(id);
+        final String fieldKey = fullConventionName.substring(meterName.length() + 1);
+
+        return new Field(fieldKey, value);
     }
 
     private Stream<String> writeFunctionTimer(FunctionTimer timer) {
@@ -222,16 +345,19 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         return Stream.of(influxLineProtocol(summary.getId(), "histogram", fields));
     }
 
-    private String influxLineProtocol(Meter.Id id, String metricType, Stream<Field> fields) {
+    private String influxLineProtocol(Meter.Id id, String metricType, Stream<Field> fields, String metricName) {
         String tags = getConventionTags(id).stream()
                 .filter(t -> StringUtils.isNotBlank(t.getValue()))
                 .map(t -> "," + t.getKey() + "=" + t.getValue())
                 .collect(joining(""));
 
-        return getConventionName(id)
-                + tags + ",metric_type=" + metricType + " "
+        return metricName + tags + ",metric_type=" + metricType + " "
                 + fields.map(Field::toString).collect(joining(","))
                 + " " + clock.wallTime();
+    }
+
+    private String influxLineProtocol(Meter.Id id, String metricType, Stream<Field> fields) {
+        return influxLineProtocol(id, metricType, fields, getConventionName(id));
     }
 
     @Override
@@ -245,6 +371,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         private Clock clock = Clock.SYSTEM;
         private ThreadFactory threadFactory = DEFAULT_THREAD_FACTORY;
         private HttpSender httpClient;
+        private Set<String> prefixes = new HashSet<>();
 
         @SuppressWarnings("deprecation")
         Builder(InfluxConfig config) {
@@ -267,8 +394,13 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
             return this;
         }
 
+        public Builder prefixes(Set<String> prefixes) {
+            this.prefixes = prefixes;
+            return this;
+        }
+
         public InfluxMeterRegistry build() {
-            return new InfluxMeterRegistry(config, clock, threadFactory, httpClient);
+            return new InfluxMeterRegistry(config, clock, threadFactory, httpClient, prefixes);
         }
     }
 
@@ -287,4 +419,50 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         }
     }
 
+    static class MeterKey {
+
+        private final Meter.Type meterType;
+        private final String prefix;
+        private final List<Tag> tags;
+        private final String baseUnit;
+
+        private MeterKey(Meter.Type meterType, String prefix, List<Tag> tags, String baseUnit) {
+            this.meterType = meterType;
+            this.prefix = prefix;
+            this.tags = tags;
+            this.baseUnit = baseUnit;
+        }
+
+        Meter.Type getMeterType() {
+            return meterType;
+        }
+
+        String getPrefix() {
+            return prefix;
+        }
+
+        List<Tag> getTags() {
+            return tags;
+        }
+
+        String getBaseUnit() {
+            return baseUnit;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof MeterKey)) return false;
+            MeterKey meterKey = (MeterKey) o;
+            return meterType == meterKey.meterType &&
+                    Objects.equals(prefix, meterKey.prefix) &&
+                    Objects.equals(tags, meterKey.tags) &&
+                    Objects.equals(baseUnit, meterKey.baseUnit);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(meterType, prefix, tags, baseUnit);
+        }
+    }
 }

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryMultipleFieldsTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryMultipleFieldsTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.influx;
+
+import com.google.common.collect.ImmutableSet;
+import io.micrometer.core.instrument.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link InfluxMeterRegistry} with multiple fields inline.
+ *
+ * @author Mariusz Sondecki
+ */
+class InfluxMeterRegistryMultipleFieldsTest {
+
+    private final InfluxConfig config = InfluxConfig.DEFAULT;
+    private final MockClock clock = new MockClock();
+    private final InfluxMeterRegistry meterRegistry = new InfluxMeterRegistry.Builder(config)
+            .clock(clock)
+            .prefixes(ImmutableSet.of("valid.metric1.name", "invalid.metric.name.", "valid.metric2.name"))
+            .build();
+
+    @Test
+    void testWriteGaugesWithSameTagsAndMultipleFields() {
+        //Given
+        meterRegistry.gauge("valid.metric1.name.my.field1", Tags.of("foo", "bar"), 1d);
+        meterRegistry.gauge("valid.metric1.name.my.field2", Tags.of("foo", "bar"), 2d);
+
+        Gauge gauge1 = meterRegistry.find("valid.metric1.name.my.field1").gauge();
+        Gauge gauge2 = meterRegistry.find("valid.metric1.name.my.field2").gauge();
+
+        final InfluxMeterRegistry.MeterKey meterKey1 = meterRegistry.createKeyIfMatched(gauge1);
+        final InfluxMeterRegistry.MeterKey meterKey2 = meterRegistry.createKeyIfMatched(gauge2);
+
+        //When
+        final List<String> gaugesInfluxLines = meterRegistry.writeMetersAsSingleMultiFieldLine(Arrays.asList(gauge1, gauge2),
+                meter -> ((Gauge) meter).value(),
+                meterRegistry.getConventionName(meterKey1))
+                .collect(Collectors.toList());
+
+        //Then
+        assertThat(meterKey1).isEqualTo(meterKey2);
+        assertThat(gaugesInfluxLines)
+                .hasSize(1)
+                .contains("valid_metric1_name,foo=bar,metric_type=gauge my_field1=1,my_field2=2 1");
+    }
+
+    @Test
+    void testWriteFunctionCountersWithSameTagsAndMultipleFields() {
+        FunctionCounter counter1 = FunctionCounter.builder("valid.metric1.name.my.field1", 1d, Number::doubleValue)
+                .tags(Tags.of("foo", "bar"))
+                .register(meterRegistry);
+        FunctionCounter counter2 = FunctionCounter.builder("valid.metric1.name.my.field2", 1d, Number::doubleValue)
+                .tags(Tags.of("foo", "bar"))
+                .register(meterRegistry);
+        clock.add(config.step());
+
+        final InfluxMeterRegistry.MeterKey meterKey1 = meterRegistry.createKeyIfMatched(counter1);
+        final InfluxMeterRegistry.MeterKey meterKey2 = meterRegistry.createKeyIfMatched(counter2);
+
+        //When
+        final List<String> countersInfluxLines = meterRegistry.writeMetersAsSingleMultiFieldLine(Arrays.asList(counter1, counter2),
+                meter -> ((FunctionCounter) meter).count(),
+                meterRegistry.getConventionName(meterKey1))
+                .collect(Collectors.toList());
+
+        //Then
+        assertThat(meterKey1).isEqualTo(meterKey2);
+        assertThat(countersInfluxLines)
+                .hasSize(1)
+                .contains("valid_metric1_name,foo=bar,metric_type=counter my_field1=1,my_field2=1 60001");
+    }
+
+    @Test
+    void testWriteGaugesWithDifferentTags() {
+        //Given
+        meterRegistry.gauge("valid.metric1.name.my.field1", Tags.of("foo1", "bar"), 1d);
+        meterRegistry.gauge("valid.metric1.name.my.field2", Tags.of("foo2", "bar"), 2d);
+
+        Gauge gauge1 = meterRegistry.find("valid.metric1.name.my.field1").gauge();
+        Gauge gauge2 = meterRegistry.find("valid.metric1.name.my.field2").gauge();
+
+        final InfluxMeterRegistry.MeterKey meterKey1 = meterRegistry.createKeyIfMatched(gauge1);
+        final InfluxMeterRegistry.MeterKey meterKey2 = meterRegistry.createKeyIfMatched(gauge2);
+
+        //When
+        final List<String> gaugesInfluxLinesForKey1 = meterRegistry.writeMetersAsSingleMultiFieldLine(Arrays.asList(gauge1),
+                meter -> ((Gauge) meter).value(),
+                meterRegistry.getConventionName(meterKey1))
+                .collect(Collectors.toList());
+        final List<String> gaugesInfluxLinesForKey2 = meterRegistry.writeMetersAsSingleMultiFieldLine(Arrays.asList(gauge2),
+                meter -> ((Gauge) meter).value(),
+                meterRegistry.getConventionName(meterKey2))
+                .collect(Collectors.toList());
+        //Then
+        assertThat(meterKey1).isNotEqualTo(meterKey2);
+        assertThat(gaugesInfluxLinesForKey1)
+                .hasSize(1)
+                .contains("valid_metric1_name,foo1=bar,metric_type=gauge my_field1=1 1");
+        assertThat(gaugesInfluxLinesForKey2)
+                .hasSize(1)
+                .contains("valid_metric1_name,foo2=bar,metric_type=gauge my_field2=2 1");
+    }
+
+    @Test
+    void testMatchingGaugesForNotSensiblePrefix() {
+        //Given
+        meterRegistry.gauge("invalid.metric.name.my.field1", Tags.of("foo", "bar"), 1d);
+        meterRegistry.gauge("invalid.metric.name.my.field2", Tags.of("foo", "bar"), 2d);
+
+        Gauge gauge1 = meterRegistry.find("invalid.metric.name.my.field1").gauge();
+        Gauge gauge2 = meterRegistry.find("invalid.metric.name.my.field2").gauge();
+
+        //When
+        final InfluxMeterRegistry.MeterKey meterKey1 = meterRegistry.createKeyIfMatched(gauge1);
+        final InfluxMeterRegistry.MeterKey meterKey2 = meterRegistry.createKeyIfMatched(gauge2);
+
+        //Then
+        assertThat(meterKey1).isNull();
+        assertThat(meterKey2).isNull();
+    }
+
+    @Test
+    void testMatchingForDifferentMeters() {
+        //Given
+        Measurement m1 = new Measurement(() -> 23d, Statistic.VALUE);
+        Measurement m2 = new Measurement(() -> 13d, Statistic.VALUE);
+        Measurement m3 = new Measurement(() -> 5d, Statistic.TOTAL_TIME);
+        Meter meter = Meter.builder("valid.metric1.name.my.custom", Meter.Type.OTHER, Arrays.asList(m1, m2, m3)).register(meterRegistry);
+
+        //When
+        final InfluxMeterRegistry.MeterKey meterKey1 = meterRegistry.createKeyIfMatched(meter);
+
+        //Then
+        assertThat(meterKey1).isNull();
+    }
+}

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile 'com.github.ben-manes.caffeine:caffeine:latest.release', optional
     compile 'net.sf.ehcache:ehcache:latest.release', optional
     compile 'javax.cache:cache-api:latest.release', optional
-    compile 'com.hazelcast:hazelcast:latest.release', optional
+    compile 'com.hazelcast:hazelcast:3.+', optional
     compile 'org.hibernate:hibernate-entitymanager:latest.release', optional
 
     // server runtime monitoring


### PR DESCRIPTION
This PR adds support for writing counters and gauges as a single multi field line in InfluxMeterRegistry grouping these meters by type, prefix, tags and prefix which is provided as a parameter. This prefix will be target name of a meter. For not grouped meters an existing logic will be applied.

copy of https://github.com/micrometer-metrics/micrometer/pull/1651